### PR TITLE
change api call to use category and use food pantry

### DIFF
--- a/wic/src/components/FoodLocations.js
+++ b/wic/src/components/FoodLocations.js
@@ -11,7 +11,7 @@ class FoodLocations extends React.Component {
 
     componentWillReceiveProps() {
         var self = this;
-        fetch('https://api.smc-connect.org/search?keyword=food&location=' + this.props.zipcode)
+        fetch('https://api.smc-connect.org/search?category=Food Pantry&location=' + this.props.zipcode)
             .then(function (response) {
                 return response.json();
             }).then(function (json) {


### PR DESCRIPTION
Use "category" instead of "keyword" in API call - for issue #5 
Search for "Food Pantry"